### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ When you record your voice sample, the first thing you do is record the environm
 * [Scipy](https://www.scipy.org/) - SciPy is a Python-based ecosystem of open-source software for mathematics, science, and engineering. 
 * [Speech Recognition](https://pypi.org/project/SpeechRecognition/) -  Library for performing speech recognition, with support for several engines and APIs, online and offline.
 * [Python Speech Features](https://python-speech-features.readthedocs.io/en/latest/) - This library provides common speech features for ASR including MFCCs and filterbank energies. 
-* [Fuzzy Wuzzy](https://github.com/seatgeek/fuzzywuzzy) - Fuzzy string matching like a boss. It uses Levenshtein Distance to calculate the differences between sequences in a simple-to-use package. 
+* [Fuzzy Wuzzy](https://github.com/maxbachmann/rapidfuzz) - Fuzzy string matching like a boss. It uses Levenshtein Distance to calculate the differences between sequences in a simple-to-use package. 
 * [Random Words](https://pypi.org/project/random-word/) - This is a simple python package to generate random english words. 
 * [Skitlearn Gaussian Mixture Models](https://scikit-learn.org/stable/modules/mixture.html) - sklearn.mixture is a package which enables one to learn Gaussian Mixture Models
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ dask==1.0.0
 decorator==4.3.0
 docutils==0.14
 Flask==1.0.2
-fuzzywuzzy==0.17.0
 idna==2.8
 imagesize==1.1.0
 itsdangerous==1.1.0
@@ -32,11 +31,11 @@ Pygments==2.3.0
 pyparsing==2.3.0
 pyssp==0.1.9.6
 python-dateutil==2.7.3
-python-Levenshtein==0.12.0
 python-speech-features==0.6
 pytz==2018.7
 PyWavelets==1.0.1
 RandomWords==0.2.1
+rapidfuzz==0.7.12
 requests==2.21.0
 scikit-image==0.14.0
 scikit-learn==0.19.2

--- a/voice.py
+++ b/voice.py
@@ -22,7 +22,7 @@ import scipy.io.wavfile
 # For the speech detection alogrithms
 import speech_recognition
 # For the fuzzy matching algorithms
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 # For using the MFCC feature selection
 from python_speech_features import mfcc
 # For generating random words


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy